### PR TITLE
Manage Chromecast shuffle queue from the web UI

### DIFF
--- a/MediaFeeder/MediaFeeder/Components/Pages/Sessions.razor
+++ b/MediaFeeder/MediaFeeder/Components/Pages/Sessions.razor
@@ -3,6 +3,7 @@
 
 <h3>Sessions</h3>
 
+<GridRow Gutter="(16, 16)" Justify="RowJustify.SpaceAround">
 @if (SessionManager != null)
 {
     @foreach (var session in SessionManager.PlaybackSessions)
@@ -12,6 +13,7 @@
         </GridCol>
     }
 }
+</GridRow>
 
 @code {
     [Inject] public PlaybackSessionManager? SessionManager { get; set; }

--- a/MediaFeeder/MediaFeeder/Components/SessionInfo.razor
+++ b/MediaFeeder/MediaFeeder/Components/SessionInfo.razor
@@ -5,7 +5,7 @@
 @using Microsoft.EntityFrameworkCore;
 
 <Card Loading="@(Session == null)" >
-    <Cover>
+    <ChildContent>
         <GridRow Gutter="16">
             <GridCol Span="8">
                 <Image
@@ -20,8 +20,7 @@
                     Description="@(Session?.Video?.Subscription?.Name)"/>
             </GridCol>
         </GridRow>
-    </Cover>
-    <ChildContent>
+
         @if (Session?.CurrentPosition != null)
         {
             <Progress

--- a/MediaFeeder/MediaFeeder/Components/SessionInfo.razor
+++ b/MediaFeeder/MediaFeeder/Components/SessionInfo.razor
@@ -4,7 +4,7 @@
 @using MediaFeeder.PlaybackManager
 @using Microsoft.EntityFrameworkCore;
 
-<Card Loading="@(Session == null)" >
+<Card Loading="@(Session == null)" Title="@(Session?.Title)">
     <ChildContent>
         <GridRow Gutter="16">
             <GridCol Span="8">

--- a/MediaFeeder/MediaFeeder/Components/SessionInfo.razor
+++ b/MediaFeeder/MediaFeeder/Components/SessionInfo.razor
@@ -1,6 +1,8 @@
 @using Humanizer
+@using MediaFeeder.Data
 @using MediaFeeder.Data.db
 @using MediaFeeder.PlaybackManager
+@using Microsoft.EntityFrameworkCore;
 
 <Card Loading="@(Session == null)" >
     <Cover>
@@ -35,6 +37,39 @@
         }
 
         <AntList Size="ListSize.Small" Style="margin-top: 16px; max-height: 300px; overflow-y: auto;" Bordered DataSource="@Session.Playlist">
+            <Header>
+                <Flex Gap="FlexGap.Small">
+                    <TreeSelect
+                        DataSource="@Session.AllFolders"
+                        @bind-Value="@Session.SelectedFolderId"
+                        Placeholder="Please select folder"
+                        ItemValue="static item => item.Id"
+                        ItemLabel="static item => item.Name"
+                        AllowClear
+                        EnableSearch
+                        MatchedStyle="font-weight: bold"
+                        ChildrenExpression="static node => node.DataItem.Subfolders"
+                        TitleExpression="static node => node.DataItem.Name"
+                        TitleTemplate="static node => node.DataItem.Name.ToRenderFragment()"
+                        KeyExpression="static node => node.DataItem.Id.ToString()"
+                        IsLeafExpression="static node => node.DataItem.Subfolders.Count == 0"/>
+                    <DropdownButton OnClick="@(() => Session?.TriggerAddVideos(60))">
+                        <ChildContent>
+                            <div>
+                                <Icon Type="@IconType.Outline.Plus"/>
+                                Add 1 Hour
+                            </div>
+                        </ChildContent>
+                        <Overlay>
+                            <Menu>
+                                <MenuItem @onclick="@(() => Session?.TriggerAddVideos(15))">15 minutes</MenuItem>
+                                <MenuItem @onclick="@(() => Session?.TriggerAddVideos(30))">30 minutes</MenuItem>
+                                <MenuItem @onclick="@(() => Session?.TriggerAddVideos(120))">2 hours</MenuItem>
+                            </Menu>
+                        </Overlay>
+                    </DropdownButton>
+                </Flex>
+            </Header>
             <ChildContent Context="item">
                 <ListItem Actions="@plActions(item)">
                     <ListItemMeta AvatarTemplate="@plThumbTpl(item)" DescriptionTemplate="@plDescTpl(item)">
@@ -54,26 +89,6 @@
                 Pause
             </div>
         </CardAction>
-        @if (Session?.HasAddVideosHandlers() ?? false)
-        {
-            <CardAction>
-                <Dropdown>
-                    <Overlay>
-                        <Menu>
-                            <MenuItem @onclick="@(() => Session?.TriggerAddVideos(15))">15 minutes</MenuItem>
-                            <MenuItem @onclick="@(() => Session?.TriggerAddVideos(30))">30 minutes</MenuItem>
-                            <MenuItem @onclick="@(() => Session?.TriggerAddVideos(60))">60 minutes</MenuItem>
-                        </Menu>
-                    </Overlay>
-                    <ChildContent>
-                        <div>
-                            <Icon Type="@IconType.Outline.Plus"/>
-                            Add Videos
-                        </div>
-                    </ChildContent>
-                </Dropdown>
-            </CardAction>
-        }
         <CardAction>
             <div @onclick="@(() => Session?.Watch())">
                 <Icon Type="@IconType.Outline.Eye"/>
@@ -94,10 +109,23 @@
     [EditorRequired]
     public PlaybackSession? Session { get; set; }
 
+    [Inject] public required MediaFeederDataContext Context { get; set; }
+
     RenderFragment plThumbTpl(Video v) => @<Avatar Shape="AvatarShape.Square" Size="AvatarSize.Large" Src="@($"api/video/{v.Id}/thumbnail/")"/>;
     RenderFragment plDescTpl(Video v) => @<span>@(v.DurationSpan.ToString() ?? "??:??") • @(v.Subscription?.Name)</span>;
     RenderFragment plRemove(Video v) => @<a key="remove" @onclick="@(() => Session?.RemoveFromPlaylist(v))">remove</a>;
     RenderFragment[] plActions(Video v) => [ plRemove(v) ];
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (Session != null)
+        {
+            Session.AllFolders = await Context.Folders
+                .Where(f => f.User == Session.User)
+                .Include(static f => f.Subfolders)
+                .ToListAsync();
+        }
+    }
 
     protected override void OnParametersSet()
     {

--- a/MediaFeeder/MediaFeeder/Components/SessionInfo.razor
+++ b/MediaFeeder/MediaFeeder/Components/SessionInfo.razor
@@ -46,6 +46,26 @@
                 Pause
             </div>
         </CardAction>
+        @if (Session?.HasAddVideosHandlers() ?? false)
+        {
+            <CardAction>
+                <Dropdown>
+                    <Overlay>
+                        <Menu>
+                            <MenuItem @onclick="@(() => Session?.TriggerAddVideos(15))">15 minutes</MenuItem>
+                            <MenuItem @onclick="@(() => Session?.TriggerAddVideos(30))">30 minutes</MenuItem>
+                            <MenuItem @onclick="@(() => Session?.TriggerAddVideos(60))">60 minutes</MenuItem>
+                        </Menu>
+                    </Overlay>
+                    <ChildContent>
+                        <div>
+                            <Icon Type="@IconType.Outline.Plus"/>
+                            Add Videos
+                        </div>
+                    </ChildContent>
+                </Dropdown>
+            </CardAction>
+        }
         <CardAction>
             <div @onclick="@(() => Session?.Watch())">
                 <Icon Type="@IconType.Outline.Eye"/>

--- a/MediaFeeder/MediaFeeder/Components/SessionInfo.razor
+++ b/MediaFeeder/MediaFeeder/Components/SessionInfo.razor
@@ -124,10 +124,11 @@
     {
         if (Session != null)
         {
-            Session.AllFolders = await Context.Folders
+            Session.AllFolders = Context.Folders
+                .AsNoTracking()
                 .Where(f => f.User == Session.User)
                 .Include(static f => f.Subfolders)
-                .ToListAsync();
+                .ToList();
         }
     }
 

--- a/MediaFeeder/MediaFeeder/Components/SessionInfo.razor
+++ b/MediaFeeder/MediaFeeder/Components/SessionInfo.razor
@@ -1,4 +1,5 @@
 @using Humanizer
+@using MediaFeeder.Data.db
 @using MediaFeeder.PlaybackManager
 
 <Card Loading="@(Session == null)" >
@@ -31,13 +32,20 @@
             <CardMeta
                 Title="@($"{Session?.Provider?.Humanize()} - {Session?.CurrentPosition?.ToString()} / {Session?.Video?.DurationSpan.ToString()}")"
                 Description="@($"{Session?.State} - {Session?.Quality} - {Session?.Rate}x - {Session?.Volume}% volume")"/>
-            <div style="padding-top: 16px;">
-                <Avatar Style="@("background-color: purple; vertical-align: middle;")" Size="AvatarSize.Large">
-                    @Session?.User.UserName[0]
-                </Avatar>
-                <span>@Session?.User.UserName</span>
-            </div>
         }
+
+        <AntList Size="ListSize.Small" Style="margin-top: 16px; max-height: 300px; overflow-y: auto;" Bordered DataSource="@Session.Playlist">
+            <ChildContent Context="item">
+                <ListItem Actions="@plActions(item)">
+                    <ListItemMeta AvatarTemplate="@plThumbTpl(item)" DescriptionTemplate="@plDescTpl(item)">
+                        <TitleTemplate>
+                            @item.Name
+                        </TitleTemplate>
+                    </ListItemMeta>
+                </ListItem>
+            </ChildContent>
+        </AntList>
+
     </ChildContent>
     <ActionTemplate>
         <CardAction >
@@ -85,6 +93,11 @@
     [Parameter]
     [EditorRequired]
     public PlaybackSession? Session { get; set; }
+
+    RenderFragment plThumbTpl(Video v) => @<Avatar Shape="AvatarShape.Square" Size="AvatarSize.Large" Src="@($"api/video/{v.Id}/thumbnail/")"/>;
+    RenderFragment plDescTpl(Video v) => @<span>@(v.DurationSpan.ToString() ?? "??:??") • @(v.Subscription?.Name)</span>;
+    RenderFragment plRemove(Video v) => @<a key="remove" @onclick="@(() => Session?.RemoveFromPlaylist(v))">remove</a>;
+    RenderFragment[] plActions(Video v) => [ plRemove(v) ];
 
     protected override void OnParametersSet()
     {

--- a/MediaFeeder/MediaFeeder/Components/SessionInfo.razor
+++ b/MediaFeeder/MediaFeeder/Components/SessionInfo.razor
@@ -39,7 +39,7 @@
             <Header>
                 <Flex Gap="FlexGap.Small">
                     <TreeSelect
-                        DataSource="@Session.AllFolders"
+                        DataSource="@allFolders"
                         @bind-Value="@Session.SelectedFolderId"
                         Placeholder="Please select folder"
                         ItemValue="static item => item.Id"
@@ -110,6 +110,8 @@
 
     [Inject] public required MediaFeederDataContext Context { get; set; }
 
+    List<Folder> allFolders = [];
+
     RenderFragment titleTpl(PlaybackSession s) => @<Flex Justify="FlexJustify.SpaceBetween">
       <span>@(s?.Provider?.Humanize())</span>
       <span>@(s?.CurrentPosition?.ToString()) / @(s?.Video?.DurationSpan.ToString())</span>
@@ -124,7 +126,7 @@
     {
         if (Session != null)
         {
-            Session.AllFolders = Context.Folders
+            allFolders = Context.Folders
                 .AsNoTracking()
                 .Where(f => f.User == Session.User)
                 .Include(static f => f.Subfolders)

--- a/MediaFeeder/MediaFeeder/Components/SessionInfo.razor
+++ b/MediaFeeder/MediaFeeder/Components/SessionInfo.razor
@@ -31,8 +31,8 @@
         }
         @if (Session?.Video != null)
         {
-            <CardMeta
-                Title="@($"{Session?.Provider?.Humanize()} - {Session?.CurrentPosition?.ToString()} / {Session?.Video?.DurationSpan.ToString()}")"
+            <CardMeta Style="display: block;"
+                TitleTemplate="@titleTpl(Session)"
                 Description="@($"{Session?.State} - {Session?.Quality} - {Session?.Rate}x - {Session?.Volume}% volume")"/>
         }
 
@@ -110,6 +110,11 @@
     public PlaybackSession? Session { get; set; }
 
     [Inject] public required MediaFeederDataContext Context { get; set; }
+
+    RenderFragment titleTpl(PlaybackSession s) => @<Flex Justify="FlexJustify.SpaceBetween">
+      <span>@(s?.Provider?.Humanize())</span>
+      <span>@(s?.CurrentPosition?.ToString()) / @(s?.Video?.DurationSpan.ToString())</span>
+      </Flex>;
 
     RenderFragment plThumbTpl(Video v) => @<Avatar Shape="AvatarShape.Square" Size="AvatarSize.Large" Src="@($"api/video/{v.Id}/thumbnail/")"/>;
     RenderFragment plDescTpl(Video v) => @<span>@(v.DurationSpan.ToString() ?? "??:??") • @(v.Subscription?.Name)</span>;

--- a/MediaFeeder/MediaFeeder/PlaybackManager/PlaybackSession.cs
+++ b/MediaFeeder/MediaFeeder/PlaybackManager/PlaybackSession.cs
@@ -20,6 +20,8 @@ public sealed class PlaybackSession : IDisposable
     public event Action? PlayPauseEvent;
     public event Action? WatchEvent;
     public event Action? SkipEvent;
+    public List<Folder> AllFolders { get; set; } = [];
+    public int SelectedFolderId { get; set; }
     public event Action<Int32>? AddVideos;
 
     public void PlayPause() => PlayPauseEvent?.Invoke();
@@ -155,8 +157,8 @@ public sealed class PlaybackSession : IDisposable
     {
         return AddVideos != null;
     }
-    public void TriggerAddVideos(int count)
+    public void TriggerAddVideos(int minutes)
     {
-        AddVideos?.Invoke(count);
+        AddVideos?.Invoke(minutes);
     }
 }

--- a/MediaFeeder/MediaFeeder/PlaybackManager/PlaybackSession.cs
+++ b/MediaFeeder/MediaFeeder/PlaybackManager/PlaybackSession.cs
@@ -6,6 +6,7 @@ namespace MediaFeeder.PlaybackManager;
 public sealed class PlaybackSession : IDisposable
 {
     private readonly PlaybackSessionManager _manager;
+    private List<Video> _playlist = [];
     private Video? _video;
     private TimeSpan? _currentPosition;
     private AuthUser _user;
@@ -35,6 +36,29 @@ public sealed class PlaybackSession : IDisposable
     public void Dispose()
     {
         _manager.RemoveSession(this);
+    }
+
+    public List<Video> Playlist => _playlist;
+
+    public void AddToPlaylist(List<Video> items)
+    {
+        _playlist.AddRange(items);
+        UpdateEvent?.Invoke();
+    }
+
+    public void RemoveFromPlaylist(Video item)
+    {
+        _playlist.Remove(item);
+        UpdateEvent?.Invoke();
+    }
+
+    public Video PopPlaylistHead()
+    {
+        if (_playlist.Count < 1) return null;
+        Video video = _playlist[0];
+        _playlist.RemoveAt(0);
+        UpdateEvent?.Invoke();
+        return video;
     }
 
     public Video? Video

--- a/MediaFeeder/MediaFeeder/PlaybackManager/PlaybackSession.cs
+++ b/MediaFeeder/MediaFeeder/PlaybackManager/PlaybackSession.cs
@@ -21,7 +21,6 @@ public sealed class PlaybackSession : IDisposable
     public event Action? PlayPauseEvent;
     public event Action? WatchEvent;
     public event Action? SkipEvent;
-    public List<Folder> AllFolders { get; set; } = [];
     public int SelectedFolderId { get; set; }
     public event Action<Int32>? AddVideos;
 

--- a/MediaFeeder/MediaFeeder/PlaybackManager/PlaybackSession.cs
+++ b/MediaFeeder/MediaFeeder/PlaybackManager/PlaybackSession.cs
@@ -19,6 +19,7 @@ public sealed class PlaybackSession : IDisposable
     public event Action? PlayPauseEvent;
     public event Action? WatchEvent;
     public event Action? SkipEvent;
+    public event Action<Int32>? AddVideos;
 
     public void PlayPause() => PlayPauseEvent?.Invoke();
     public void Watch() => WatchEvent?.Invoke();
@@ -124,5 +125,14 @@ public sealed class PlaybackSession : IDisposable
             _loaded = value;
             UpdateEvent?.Invoke();
         }
+    }
+
+    public bool HasAddVideosHandlers()
+    {
+        return AddVideos != null;
+    }
+    public void TriggerAddVideos(int count)
+    {
+        AddVideos?.Invoke(count);
     }
 }

--- a/MediaFeeder/MediaFeeder/PlaybackManager/PlaybackSession.cs
+++ b/MediaFeeder/MediaFeeder/PlaybackManager/PlaybackSession.cs
@@ -16,6 +16,7 @@ public sealed class PlaybackSession : IDisposable
     private int? _volume;
     private float? _rate;
     private float? _loaded;
+    public string? Title { get; set; }
     public event Action? UpdateEvent;
     public event Action? PlayPauseEvent;
     public event Action? WatchEvent;

--- a/MediaFeeder/MediaFeeder/Services/Api.proto
+++ b/MediaFeeder/MediaFeeder/Services/Api.proto
@@ -143,23 +143,29 @@ message ShuffleReply {
   repeated int32 Id = 1;
 }
 
+enum PlaybackSessionAction {
+  NO_SESSION_ACTION = 0;
+  POP_NEXT_VIDEO = 1;
+}
+
 message PlaybackSessionRequest {
+  PlaybackSessionAction Action = 1;
   optional int32 VideoId = 2;
   optional int32 Duration = 3;
   optional string Quality = 4;
   optional string Provider = 5;
   optional string State = 6;
   optional int32 Volume = 7;
-  optional float  Rate = 8;
+  optional float Rate = 8;
   optional float Loaded = 9;
-  optional bool EndSession = 10;
+  optional bool EndSession = 10;  // TODO move to Action.
 }
 
 message PlaybackSessionReply {
   optional bool ShouldPlayPause = 1;
   optional bool ShouldWatch = 2;
   optional bool ShouldSkip = 3;
-  optional int32 AddMinutes = 4;
+  optional int32 NextVideoId = 4;
 }
 
 message UnwatchedCounts {

--- a/MediaFeeder/MediaFeeder/Services/Api.proto
+++ b/MediaFeeder/MediaFeeder/Services/Api.proto
@@ -150,6 +150,7 @@ enum PlaybackSessionAction {
 
 message PlaybackSessionRequest {
   PlaybackSessionAction Action = 1;
+  optional string Title = 11;
   optional int32 VideoId = 2;
   optional int32 Duration = 3;
   optional string Quality = 4;

--- a/MediaFeeder/MediaFeeder/Services/Api.proto
+++ b/MediaFeeder/MediaFeeder/Services/Api.proto
@@ -159,6 +159,7 @@ message PlaybackSessionReply {
   optional bool ShouldPlayPause = 1;
   optional bool ShouldWatch = 2;
   optional bool ShouldSkip = 3;
+  optional int32 AddMinutes = 4;
 }
 
 message UnwatchedCounts {

--- a/MediaFeeder/MediaFeeder/Services/ApiService.cs
+++ b/MediaFeeder/MediaFeeder/Services/ApiService.cs
@@ -466,11 +466,13 @@ public sealed class ApiService(
 
         await using var db = await contextFactory.CreateDbContextAsync(context.CancellationToken);
 
+        // TODO pass some kinda init block to this so listeners only see the ready object?
         using var session = playbackSessionManager.NewSession(user);
 
         session.PlayPauseEvent += async () => await responseStream.WriteAsync(new PlaybackSessionReply { ShouldPlayPause = true }, context.CancellationToken);
         session.SkipEvent += async () => await responseStream.WriteAsync(new PlaybackSessionReply { ShouldSkip = true }, context.CancellationToken);
         session.WatchEvent += async () => await responseStream.WriteAsync(new PlaybackSessionReply { ShouldWatch = true }, context.CancellationToken);
+        session.AddVideos += async minutes => await responseStream.WriteAsync(new PlaybackSessionReply { AddMinutes = minutes }, context.CancellationToken);
 
         while (!context.CancellationToken.IsCancellationRequested)
         {

--- a/MediaFeeder/MediaFeeder/Services/ApiService.cs
+++ b/MediaFeeder/MediaFeeder/Services/ApiService.cs
@@ -491,12 +491,13 @@ public sealed class ApiService(
         session.WatchEvent += async () => await responseStream.WriteAsync(new PlaybackSessionReply { ShouldWatch = true }, context.CancellationToken);
         session.AddVideos += async minutes =>
         {
+            if (session.SelectedFolderId < 1) return;
             var videos = await DoShuffle(
                 db,
                 user,
                 minutes,
-                1, // TODO
-                -1); // TODO
+                session.SelectedFolderId,
+                -1);
             session.AddToPlaylist(videos);
         };
 

--- a/MediaFeeder/MediaFeeder/Services/ApiService.cs
+++ b/MediaFeeder/MediaFeeder/Services/ApiService.cs
@@ -513,6 +513,9 @@ public sealed class ApiService(
                         break;
                 }
 
+                if (requestStream.Current.HasTitle)
+                    session.Title = requestStream.Current.Title;
+
                 if (requestStream.Current.HasDuration)
                     session.CurrentPosition = requestStream.Current.Duration != null ? TimeSpan.FromSeconds(requestStream.Current.Duration) : null;
 

--- a/scripts/youtube_shuffle.py
+++ b/scripts/youtube_shuffle.py
@@ -197,7 +197,10 @@ try:
                 if current_video_id and event.mark_watched:
                     print(f"Marking {current_video_id} as watched...")
                     stub.Watched(Api_pb2.WatchedRequest(Id=current_video_id, Watched=True))
-                    current_video_id = None
+
+                current_video_id = None
+                current_content_id = None
+                print("Requesting next video...")
                 status_message_queue.put(Api_pb2.PlaybackSessionRequest(Action = Api_pb2.POP_NEXT_VIDEO))
             else:
                 print(f"Ignoring event: {event}")

--- a/scripts/youtube_shuffle.py
+++ b/scripts/youtube_shuffle.py
@@ -199,6 +199,13 @@ try:
 
             print(f"Playing {current_video_id}: {id_response.Title} [{current_content_id}]")
             status_message_queue.put(Api_pb2.PlaybackSessionRequest(VideoId = current_video_id))
+
+            # if the chromecast has been used for other apps, cast lib might incorrectly think it is already launched.
+            # this makes sure it reconnects and is ready to receive play commands.  hopefully.
+            yt.update_screen_id()
+            yt.start_session_if_none()
+            time.sleep(1)
+
             yt.clear_playlist()
             yt.play_video(current_content_id)
 
@@ -213,7 +220,7 @@ try:
                 current_content_id = None
                 print("Requesting next video...")
                 status_message_queue.put(Api_pb2.PlaybackSessionRequest(Action = Api_pb2.POP_NEXT_VIDEO))
-                time.sleep(1)  # let chromecast finish before tring to play next video.
+                time.sleep(1)  # let chromecast finish before trying to play next video.
             else:
                 print(f"Ignoring event: {event}")
 except KeyboardInterrupt:

--- a/scripts/youtube_shuffle.py
+++ b/scripts/youtube_shuffle.py
@@ -162,7 +162,7 @@ cast.media_controller.register_status_listener(listenerMedia)
 session_reader = None
 
 def ConnectToServer():
-    global listenerMedia, status_message_queue, executor, session_reader
+    global listenerMedia, status_message_queue, executor, session_reader, cast
 
     if session_reader:
         session_reader.cancel()
@@ -170,6 +170,7 @@ def ConnectToServer():
     print("Connecting to server...")
     session_iterator = stub.PlaybackSession(message_queue_iterator(status_message_queue))
     session_reader = executor.submit(listenerMedia.on_ses_rep, session_iterator)
+    status_message_queue.put(Api_pb2.PlaybackSessionRequest(Title = cast.name))
 
 def UpdateCast():
     global cast

--- a/scripts/youtube_shuffle.py
+++ b/scripts/youtube_shuffle.py
@@ -189,6 +189,10 @@ try:
         if not session_reader or not session_reader.running():
             ConnectToServer()
 
+            # if connection was lost, at least restore what is currently playing.
+            if current_video_id:
+                status_message_queue.put(Api_pb2.PlaybackSessionRequest(VideoId = current_video_id))
+
         if current_video_id and not UpdateCast():
             continue
 


### PR DESCRIPTION
I would very appreciate feedback on all the dotnet code changes.

Summary of features:

- Make sessions page layout cards correctly, particularly with multiple cards.
- Add play queue to session card with controls to add a duration of videos from a folder and then options to remove individual videos.
- Various layout tweaks and fixes to the session card.
- Removed username from session card since we are not using multiuser setups and it took up a lot of space.
- Show which chromecast each card is for.

For youtube_shuffle.py :
- Make it maintain a connection to the server and reconnect when it drops.
- Give it a bit of an event queue structure to fix some ordering issues.
- Various event logging to aid RPC debugging.
- Make it reconnect to lost chromecasts.
- CLI args for self-signed certs.
- Some state tracking so it mostly recovers from strange situations.

Things for future changes:

- If the streaming RPC connection drops for any reason the session, including queue, is lost.  It would be nice if the server kept the session around for the script to reconnect to.
- Streaming RPC messages are kinda messy/inconsistent in structure.
- Tidy youtube_shuffle.py to be more class/instance structured and less global vars.

And finally the most confusing bug: the streaming RPC seems to keep getting into a state where client->server msgs wander off into the ether never to be seen again, even through everything is running on the same machine.  Seems particularly prone in the first ~10 seconds of streaming connection, often loosing the session title on reconnects.

Given the way GRPC keeps persistent TCP connections etc, i am wondering if streaming RPC is really the right answer here anyway?  It would be much simpler to use simple RPC calls CreateSession(), Play(), Pause(), etc methods with no notable performance changes.  If we want high resolution updates in the UI for play timestamp, etc, those could be streamed alongside the discrete command calls.  Something for a future change and why i have not put much effort into cleaning up the RPCs in the CL.